### PR TITLE
🧹 Remove unused struct fields in Session

### DIFF
--- a/main.go
+++ b/main.go
@@ -29,24 +29,18 @@ func (bkd *Backend) NewSession(_ *smtp.Conn) (smtp.Session, error) {
 
 // A Session is returned after EHLO.
 type Session struct {
-	auth bool
-	from string
-	to   string
 }
 
 func (s *Session) AuthPlain(username, password string) error {
 	// Don't care about auth
-	s.auth = true
 	return nil
 }
 
 func (s *Session) Mail(from string, opts *smtp.MailOptions) error {
-	s.from = from
 	return nil
 }
 
 func (s *Session) Rcpt(to string, opts *smtp.RcptOptions) error {
-	s.to = to
 	return nil
 }
 


### PR DESCRIPTION
This PR improves code health by removing unused fields from the `Session` struct.

🎯 **What:** Removed the `auth`, `from`, and `to` fields from the `Session` struct in `main.go` and their corresponding assignments in the `AuthPlain`, `Mail`, and `Rcpt` methods.
💡 **Why:** These fields were never read, making them dead code. Removing them improves maintainability and readability by reducing clutter.
✅ **Verification:** 
- Manually inspected `main.go` to ensure no other references to these fields existed.
- Created an isolated test that mocked the `smtp` package's expected method signatures and verified that the refactored `Session` struct still correctly implements the required interface.
- Confirmed that method signatures remain intact to avoid breaking interface compliance.
✨ **Result:** A cleaner `Session` struct and methods, with no change in the application's behavior.

---
*PR created automatically by Jules for task [12242388980524301278](https://jules.google.com/task/12242388980524301278) started by @dwhillis*