### PR TITLE
🧪 Add test for makeBasePath function

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"crypto/tls"
+	"net/http"
+	"testing"
+)
+
+func TestMakeBasePath(t *testing.T) {
+	tests := []struct {
+		name     string
+		req      *http.Request
+		expected string
+	}{
+		{
+			name: "HTTP Request",
+			req: &http.Request{
+				Host: "example.com",
+			},
+			expected: "http://example.com",
+		},
+		{
+			name: "HTTPS Request",
+			req: &http.Request{
+				Host: "example.com",
+				TLS:  &tls.ConnectionState{},
+			},
+			expected: "https://example.com",
+		},
+		{
+			name: "HTTP Request with custom port",
+			req: &http.Request{
+				Host: "example.com:8080",
+			},
+			expected: "http://example.com:8080",
+		},
+		{
+			name: "HTTPS Request with custom port",
+			req: &http.Request{
+				Host: "example.com:8443",
+				TLS:  &tls.ConnectionState{},
+			},
+			expected: "https://example.com:8443",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := makeBasePath(tc.req)
+			if result != tc.expected {
+				t.Errorf("Expected %s, got %s", tc.expected, result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
🎯 **What:** The testing gap addressed is the lack of unit tests for the `makeBasePath` utility function, which builds the base URL for the server based on the incoming request properties (scheme and host).

📊 **Coverage:** The new tests cover:
- Standard HTTP requests (without TLS)
- HTTPS requests (with TLS defined)
- HTTP requests with a custom port in the Host header
- HTTPS requests with a custom port in the Host header

✨ **Result:** Increased test coverage for HTTP routing utilities, ensuring the base path is always accurately determined regardless of request scheme or port.

---
*PR created automatically by Jules for task [2543473460477666199](https://jules.google.com/task/2543473460477666199) started by @dwhillis*